### PR TITLE
fix(analytics): Fix Plausible self-hosted rewrites and layout placement

### DIFF
--- a/rewrites.js
+++ b/rewrites.js
@@ -1,33 +1,13 @@
 const rewrites = async () => [
 	{
-		source: '/plausible/js/script.js',
-		destination: 'http://plausible.net-work.studio/js/script.js',
-	},
-	{
-		source: '/plausible/js/plausible.hash.outbound-links.js',
-		destination:
-			'http://plausible.net-work.studio/js/plausible.hash.outbound-links.js',
-	},
-	{
-		source: '/plausible/js/plausible.file-downloads.hash.outbound-links.js',
-		destination:
-			'http://plausible.net-work.studio/js/plausible.file-downloads.hash.outbound-links.js',
-	},
-	{
 		source:
-			'/plausible/js/plausible.file-downloads.hash.outbound-links.tagged-events.js',
+			'/plausible/js/plausible.file-downloads.hash.outbound-links.pageview-props.tagged-events.js',
 		destination:
-			'http://plausible.net-work.studio/js/plausible.file-downloads.hash.outbound-links.tagged-events.js',
-	},
-	{
-		source:
-			'/plausible/js/script.file-downloads.hash.outbound-links.pageview-props.tagged-events.js',
-		destination:
-			'http://plausible.net-work.studio/js/script.file-downloads.hash.outbound-links.pageview-props.tagged-events.js',
+			'https://plausible.net-work.studio/js/plausible.file-downloads.hash.outbound-links.pageview-props.tagged-events.js',
 	},
 	{
 		source: '/api/event',
-		destination: 'http://plausible.net-work.studio/api/event',
+		destination: 'https://plausible.net-work.studio/api/event',
 	},
 ];
 

--- a/src/app/(frontend)/[locale]/layout.tsx
+++ b/src/app/(frontend)/[locale]/layout.tsx
@@ -95,26 +95,26 @@ export default async function RootLayout({ children, params }: Readonly<Args>) {
 
 	return (
 		<html lang={locale}>
-			<PlausibleProviderWrapper>
-				<NextIntlClientProvider messages={messages}>
-					<ReactLenis root>
-						<LivePreviewListener />
-						<body
-							className={cn(
-								ghost.variable,
-								tagada.variable,
-								greed.variable,
-								'antialiased flex flex-col justify-between h-dvh'
-							)}
-						>
+			<body
+				className={cn(
+					ghost.variable,
+					tagada.variable,
+					greed.variable,
+					'antialiased flex flex-col justify-between h-dvh'
+				)}
+			>
+				<PlausibleProviderWrapper>
+					<NextIntlClientProvider messages={messages}>
+						<ReactLenis root>
+							<LivePreviewListener />
 							<Header />
 							<main className='mb-auto'>{children}</main>
 							<NewsletterSignup />
 							<Footer />
-						</body>
-					</ReactLenis>
-				</NextIntlClientProvider>
-			</PlausibleProviderWrapper>
+						</ReactLenis>
+					</NextIntlClientProvider>
+				</PlausibleProviderWrapper>
+			</body>
 		</html>
 	);
 }


### PR DESCRIPTION
Use HTTPS for Plausible proxy destinations, remove redundant rewrite rules, fix script name mismatch (script → plausible) to match what next-plausible generates with selfHosted=true, and move PlausibleProviderWrapper inside <body>.