### PR TITLE
fix(build): Resolve build failures for Next.js 16 Cache Components

### DIFF
--- a/src/app/(frontend)/[locale]/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/[locale]/blog/[slug]/page.tsx
@@ -40,7 +40,9 @@ export async function generateStaticParams() {
 		}
 	}
 
-	return Array.from(slugSet).map((slug) => ({ slug }));
+	const slugs = Array.from(slugSet).map((slug) => ({ slug }));
+
+	return slugs.length > 0 ? slugs : [{ slug: '_placeholder' }];
 }
 
 async function BlogPostContent({

--- a/src/app/(frontend)/[locale]/not-found.tsx
+++ b/src/app/(frontend)/[locale]/not-found.tsx
@@ -1,16 +1,18 @@
 'use client';
 
 import { useLocale, useTranslations } from 'next-intl';
-import { usePlausible } from 'next-plausible';
+import { useEffect } from 'react';
 import { Link } from '@/i18n/routing';
 import { Button } from '@/modules/components/ui/button';
 
 export default function NotFound() {
-	const plausible = usePlausible();
 	const locale = useLocale();
 	const t = useTranslations('404');
 
-	plausible('404');
+	useEffect(() => {
+		const w = window as unknown as { plausible?: (event: string) => void };
+		w.plausible?.('404');
+	}, []);
 	return (
 		<div className='flex flex-col items-center justify-center gap-4'>
 			<div className='flex flex-col gap-2 items-center justify-center'>

--- a/src/app/(frontend)/[locale]/page.tsx
+++ b/src/app/(frontend)/[locale]/page.tsx
@@ -18,6 +18,10 @@ export default async function Home({ params }: HomeProps) {
 	const { locale } = await params;
 	const home = (await getGlobal('home', 2, locale as Locales)) as HomeType;
 
+	if (!home?.hero_title) {
+		return <main className='mb-auto' />;
+	}
+
 	return (
 		<main className='mb-auto'>
 			<SectionHero home={home} />


### PR DESCRIPTION
Remove leftover next-plausible import in not-found page, use global window.plausible via useEffect instead. Return placeholder slug in generateStaticParams when no posts exist to satisfy Cache Components requirement. Add null guard on home page for empty global data.