### PR TITLE
fix(images): reduce Vercel Image Optimization cache writes by ~95%

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,10 +11,9 @@ const nextConfig = {
 	typedRoutes: true,
 	cacheComponents: true,
 	images: {
-		deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
-		imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+		deviceSizes: [640, 1080, 1920],
+		imageSizes: [32, 64, 256],
 		formats: ['image/avif', 'image/webp'],
-		qualities: [25, 30, 60, 75, 80, 90, 100],
 		remotePatterns: [
 			{
 				protocol: 'http',


### PR DESCRIPTION
## Summary
- Trimmed `deviceSizes` from 8 to 3 entries: `[640, 1080, 1920]`
- Trimmed `imageSizes` from 8 to 3 entries: `[32, 64, 256]`
- Removed custom `qualities` array (falls back to default 75; per-component `quality` prop still works)
- Reduces image variants from ~224 to 12 per image (~95% reduction), staying within Vercel free-tier limits

## Test plan
- [x] `pnpm typecheck` — no new errors
- [x] `pnpm build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)