### PR TITLE
fix(events): Hide sub-events tab until saved and fix slug generation

### DIFF
--- a/src/modules/events/collection.ts
+++ b/src/modules/events/collection.ts
@@ -170,7 +170,7 @@ export const Events: CollectionConfig = {
 				{
 					label: 'Sotto-eventi',
 					admin: {
-						condition: (data) => !data?.parent,
+						condition: (data) => !data?.parent && Boolean(data?.id),
 					},
 					fields: [
 						{
@@ -187,6 +187,7 @@ export const Events: CollectionConfig = {
 									'address.location',
 								],
 								allowCreate: true,
+								condition: (data) => !data?.parent && Boolean(data?.id),
 							},
 						},
 					],
@@ -268,7 +269,7 @@ export const Events: CollectionConfig = {
 				},
 			],
 		},
-		...slugFieldFromItalian('title'),
+		...slugFieldFromItalian('title', {}, 'events'),
 	],
 	versions: {
 		drafts: {

--- a/src/modules/payload/fields/slug/index.ts
+++ b/src/modules/payload/fields/slug/index.ts
@@ -9,7 +9,8 @@ interface Overrides {
 
 type Slug = (
 	fieldToUse?: string,
-	overrides?: Overrides
+	overrides?: Overrides,
+	collectionSlug?: string
 ) => [TextField, CheckboxField];
 
 export const slugField: Slug = (fieldToUse = 'title', overrides = {}) => {
@@ -61,7 +62,8 @@ export const slugField: Slug = (fieldToUse = 'title', overrides = {}) => {
  */
 export const slugFieldFromItalian: Slug = (
 	fieldToUse = 'title',
-	overrides = {}
+	overrides = {},
+	collectionSlug = 'posts'
 ) => {
 	const { slugOverrides, checkboxOverrides } = overrides;
 
@@ -84,7 +86,7 @@ export const slugFieldFromItalian: Slug = (
 		...(slugOverrides || {}),
 		hooks: {
 			// Use the Italian-specific hook for consistent slug generation
-			beforeValidate: [formatSlugFromItalianHook(fieldToUse, 'posts')],
+			beforeValidate: [formatSlugFromItalianHook(fieldToUse, collectionSlug)],
 		},
 		admin: {
 			...(slugOverrides?.admin || {}),


### PR DESCRIPTION
Prevent sub-events tab and relationship field from showing on unsaved events by requiring data.id. Pass collection slug to slugFieldFromItalian so events generate slugs correctly instead of defaulting to 'posts'.