### PR TITLE
chore: update program labels order

### DIFF
--- a/src/app/(frontend)/[locale]/eventi/page.tsx
+++ b/src/app/(frontend)/[locale]/eventi/page.tsx
@@ -131,7 +131,7 @@ export default async function EventiPage({ params }: EventiPageProps) {
 				fallback={
 					<section className='px-5 pb-10 pt-10 lg:px-10'>
 						<div className='grid grid-cols-1 gap-8 md:grid-cols-4 lg:grid-cols-4 animate-pulse'>
-							{Array.from({ length: 3 }).map((_, i) => (
+							{Array.from({ length: 4 }).map((_, i) => (
 								// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
 								<div className='rounded-lg overflow-hidden' key={i}>
 									<div className='h-48 bg-gray-200' />

--- a/src/app/(frontend)/[locale]/eventi/page.tsx
+++ b/src/app/(frontend)/[locale]/eventi/page.tsx
@@ -85,7 +85,7 @@ async function EventList({
 		<>
 			<section className='px-5 pb-10 pt-10 lg:px-10'>
 				{upcomingEvents.length > 0 ? (
-					<div className='grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3'>
+					<div className='grid grid-cols-1 gap-8 md:grid-cols-4 lg:grid-cols-4'>
 						{upcomingEvents.map((event) => (
 							<EventCard event={event} key={event.id} />
 						))}

--- a/src/app/(frontend)/[locale]/eventi/page.tsx
+++ b/src/app/(frontend)/[locale]/eventi/page.tsx
@@ -130,7 +130,7 @@ export default async function EventiPage({ params }: EventiPageProps) {
 			<Suspense
 				fallback={
 					<section className='px-5 pb-10 pt-10 lg:px-10'>
-						<div className='grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3 animate-pulse'>
+						<div className='grid grid-cols-1 gap-8 md:grid-cols-4 lg:grid-cols-4 animate-pulse'>
 							{Array.from({ length: 3 }).map((_, i) => (
 								// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
 								<div className='rounded-lg overflow-hidden' key={i}>

--- a/src/modules/components/EventCard.tsx
+++ b/src/modules/components/EventCard.tsx
@@ -66,7 +66,7 @@ export default async function EventCard({
 		: 'group flex flex-col group gap-5';
 	const imageWrapperClass = isCompact
 		? 'aspect-4/3 overflow-hidden rounded-[20px] bg-black/5'
-		: 'aspect-video overflow-hidden rounded-4xl';
+		: 'aspect-4/5 overflow-hidden rounded-4xl';
 	const imageClass = isCompact
 		? 'object-cover rounded-[20px] transition-transform duration-500 group-hover:scale-105'
 		: 'object-cover rounded-4xl transition-transform duration-500 group-hover:scale-105';
@@ -93,7 +93,7 @@ export default async function EventCard({
 
 			{isCompact ? (
 				<div className='flex justify-between px-1'>
-					<p className='font-greed h-fit uppercase transition-colors duration-500 group-hover:bg-rosso-500 text-base font-bold '>
+					<p className='font-greed h-fit uppercase transition-colors duration-500 group-hover:bg-rosso-500 text-balance text-base font-bold '>
 						{event.title}
 					</p>
 					<p className='font-greed h-fit uppercase transition-colors duration-500 group-hover:bg-rosso-500 text-base font-bold '>
@@ -112,7 +112,7 @@ export default async function EventCard({
 					</div>
 
 					<hgroup className='flex flex-col gap-1'>
-						<h3 className='font-tagada px-1 text-3xl leading-tight tracking-wide lg:text-4xl'>
+						<h3 className='font-tagada text-pretty px-1 text-3xl leading-tight tracking-wide lg:text-4xl'>
 							{event.title}
 						</h3>
 

--- a/src/modules/components/shared/Header.tsx
+++ b/src/modules/components/shared/Header.tsx
@@ -163,7 +163,7 @@ export default function Header() {
 								<li
 									className='w-full flex items-center justify-center animate-fade-slide-in opacity-0 motion-reduce:animate-none motion-reduce:opacity-100'
 									style={{
-										animationDelay: `${250 + 4 * 100}ms`,
+										animationDelay: `${250 + navItems.length * 100}ms`,
 										animationFillMode: 'forwards',
 									}}
 								>

--- a/src/modules/components/shared/Header.tsx
+++ b/src/modules/components/shared/Header.tsx
@@ -64,6 +64,7 @@ export default function Header() {
 				activeColor: 'underline',
 			},
 			{ href: '/blog', label: t('blog'), activeColor: 'underline' },
+			{ href: '/eventi', label: t('eventi'), activeColor: 'underline' },
 			{
 				href: '/about',
 				label: t('about'),

--- a/src/modules/events/components/EventContentSection.tsx
+++ b/src/modules/events/components/EventContentSection.tsx
@@ -19,7 +19,7 @@ export async function EventContentSection({
 
 	return (
 		<section className='px-5 py-15 md:py-20 lg:px-10 xl:px-20'>
-			<div className='grid pl-0 md:pl-25 grid-cols-1 gap-8 lg:grid-cols-[3fr_2fr]'>
+			<div className='grid pl-0 md:px-20 grid-cols-1 gap-8 lg:grid-cols-[3fr_2fr]'>
 				{/* Left: Content blocks */}
 				<div>
 					{event.content && event.content.length > 0 && (

--- a/src/modules/events/components/EventHero.tsx
+++ b/src/modules/events/components/EventHero.tsx
@@ -24,8 +24,8 @@ export function EventHero({
 	const bookingLabel = event.bookingLabel || 'Eventbrite';
 
 	return (
-		<section className='px-5 flex flex-col md:flex-row pt-20 md:pt-24 pb-10 lg:px-10 xl:px-20'>
-			<div className='w-30 pb-4 md:pb-0'>
+		<section className='px-5 flex  flex-col md:flex-row pt-20 md:pt-24 pb-10 lg:px-10 xl:px-20'>
+			<div className='w-30 pb-4 pt-0.5 md:pb-0'>
 				<Link
 					aria-label={backLabel}
 					className='flex size-12 items-center justify-center rounded-[14px] border-2 border-black transition-colors hover:bg-black/5'
@@ -35,10 +35,10 @@ export function EventHero({
 				</Link>
 			</div>
 
-			<div className='grid grid-cols-1 items-start gap-8 lg:grid-cols-2'>
+			<div className=' items-start gap-4 md:gap-8 flex flex-col md:flex-row'>
 				{/* Cover Image */}
 				{image && (
-					<div className='aspect-4/5 overflow-hidden rounded-4xl'>
+					<div className='aspect-4/5 max-h-160 overflow-hidden rounded-4xl'>
 						<CustomImage
 							alt={image.alt || event.title}
 							className='object-cover rounded-4xl'
@@ -54,7 +54,7 @@ export function EventHero({
 				{/* Title, Organizer, Booking, Links */}
 				<div className='flex flex-col pt-1 justify-between h-full gap-1'>
 					<div className='flex gap-1 flex-col'>
-						<h1 className='font-tagada text-5xl tracking-wide lg:text-7xl'>
+						<h1 className='font-tagada text-4xl md:text-5xl text-balance tracking-wide lg:text-7xl'>
 							{event.title}
 						</h1>
 

--- a/src/modules/events/labels.ts
+++ b/src/modules/events/labels.ts
@@ -2,8 +2,8 @@ export const SUB_EVENT_LABEL_ORDER = [
 	'esplorazioni',
 	'approfondimenti',
 	'attivita-piccoli',
-	'talk-musica-arte',
 	'esposizioni-voci',
+	'talk-musica-arte',
 ] as const;
 
 export type SubEventLabel = (typeof SUB_EVENT_LABEL_ORDER)[number];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved `talk-musica-arte` after `esposizioni-voci` in `SUB_EVENT_LABEL_ORDER`; restored the `eventi` link, switched the eventi page to a 4‑column grid, and matched the skeleton columns and item count to avoid layout shifts. Tweaked EventCard aspect ratio, EventHero layout/title sizing, EventContentSection padding, and fixed the mobile menu stagger by using `navItems.length` for the delay.

<sup>Written for commit e3e6d73383d28d4f9215b7861eeedacf63d60f2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

