### PR TITLE
Remove text alignment features from rich text editors

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -8,9 +8,7 @@ import { ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997e
 import { HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { IndentFeatureClient as IndentFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { UploadFeatureClient as UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { StrikethroughFeatureClient as StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
@@ -52,9 +50,7 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#IndentFeatureClient": IndentFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#StrikethroughFeatureClient": StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,

--- a/src/modules/blocks/quote/config.ts
+++ b/src/modules/blocks/quote/config.ts
@@ -1,5 +1,4 @@
 import {
-	AlignFeature,
 	BlockquoteFeature,
 	BoldFeature,
 	InlineToolbarFeature,
@@ -7,6 +6,7 @@ import {
 	LinkFeature,
 	lexicalEditor,
 	ParagraphFeature,
+	UnderlineFeature,
 } from '@payloadcms/richtext-lexical';
 import type { Block } from 'payload';
 import { alignFields } from '../common';
@@ -24,7 +24,7 @@ export const QuoteBlock: Block = {
 					InlineToolbarFeature(),
 					BoldFeature(),
 					ItalicFeature(),
-					AlignFeature(),
+					UnderlineFeature(),
 					BlockquoteFeature(),
 					LinkFeature(),
 					ParagraphFeature(),

--- a/src/modules/components/EventCard.tsx
+++ b/src/modules/components/EventCard.tsx
@@ -1,5 +1,5 @@
 import type { Event, Image as ImageType } from '@payload-types';
-import { getLocale, getTranslations } from 'next-intl/server';
+import { getLocale } from 'next-intl/server';
 import { Link } from '@/i18n/routing';
 import { getEventHref } from '@/modules/events/paths';
 import { formatEventDateTime } from '@/modules/events/utils';
@@ -49,10 +49,7 @@ export default async function EventCard({
 	showImage = true,
 	variant = 'default',
 }: EventCardProps) {
-	const [locale, t] = await Promise.all([
-		getLocale(),
-		getTranslations('events'),
-	]);
+	const locale = await getLocale();
 	const image =
 		event.coverImage && typeof event.coverImage !== 'string'
 			? (event.coverImage as ImageType)

--- a/src/modules/editor/lexical.ts
+++ b/src/modules/editor/lexical.ts
@@ -1,5 +1,4 @@
 import {
-	AlignFeature,
 	BoldFeature,
 	HeadingFeature,
 	HorizontalRuleFeature,
@@ -9,7 +8,6 @@ import {
 	LinkFeature,
 	lexicalEditor,
 	ParagraphFeature,
-	StrikethroughFeature,
 	UnderlineFeature,
 	UploadFeature,
 } from '@payloadcms/richtext-lexical';
@@ -20,9 +18,7 @@ export const defaultLexical = lexicalEditor({
 		BoldFeature(),
 		ItalicFeature(),
 		UnderlineFeature(),
-		StrikethroughFeature(),
 		UploadFeature(),
-		AlignFeature(),
 		IndentFeature(),
 		HorizontalRuleFeature(),
 		HeadingFeature({
@@ -39,8 +35,6 @@ export const minimalLexical = lexicalEditor({
 		BoldFeature(),
 		ItalicFeature(),
 		UnderlineFeature(),
-		StrikethroughFeature(),
-		AlignFeature(),
 		ParagraphFeature(),
 		HorizontalRuleFeature(),
 		LinkFeature(),

--- a/src/modules/payload/fields/slug/index.ts
+++ b/src/modules/payload/fields/slug/index.ts
@@ -28,7 +28,7 @@ type Slug = (
 export const slugField: Slug = (
 	fieldToUse = 'title',
 	overrides = {},
-	_collectionSlug
+	_collectionSlug = undefined
 ) => {
 	const { slugOverrides, checkboxOverrides } = overrides;
 

--- a/src/modules/utilities/lenis.tsx
+++ b/src/modules/utilities/lenis.tsx
@@ -23,6 +23,7 @@ function ScrollToTop({ useLenis }: { useLenis: UseLenisHook }) {
 	const lenis = useLenis();
 	const lenisRef = useRef(lenis);
 	lenisRef.current = lenis;
+	const previousPathnameRef = useRef(pathname);
 	const isFirstRender = useRef(true);
 	const isPopstateNav = useRef(false);
 
@@ -43,8 +44,13 @@ function ScrollToTop({ useLenis }: { useLenis: UseLenisHook }) {
 	useEffect(() => {
 		if (isFirstRender.current) {
 			isFirstRender.current = false;
+			previousPathnameRef.current = pathname;
 			return;
 		}
+		if (previousPathnameRef.current === pathname) {
+			return;
+		}
+		previousPathnameRef.current = pathname;
 		if (isPopstateNav.current) {
 			isPopstateNav.current = false;
 			return;


### PR DESCRIPTION
## Summary
- Removed text alignment and strikethrough features from the Payload Lexical editor setup and regenerated the admin import map accordingly.
- Updated the quote block editor config to use underline formatting instead of alignment controls.
- Simplified `EventCard` locale loading by dropping an unused translations fetch.
- Added a pathname guard in the Lenis scroll helper to avoid redundant scroll handling on unchanged routes.
- Kept the slug field helper signature explicit by defaulting the collection slug parameter to `undefined`.

## Testing
- Not run (not requested).
- Verified the diff for the affected editor configs, UI component, slug helper, and Lenis scroll utility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed text alignment and strikethrough from rich text editors to simplify formatting and keep content consistent. Also fixes redundant scroll-to-top when the route doesn’t change.

- **Refactors**
  - Removed alignment and strikethrough from `@payloadcms/richtext-lexical` default/minimal configs and cleaned up the admin import map.
  - Switched the Quote block to underline; dropped an unused `next-intl/server` translations fetch in EventCard; kept the slug helper’s collection param explicit.

- **Bug Fixes**
  - Added a pathname guard to the Lenis scroll helper to prevent duplicate scroll on unchanged routes.

<sup>Written for commit 9664adea4fc19a835b065c01114adf23838ed070. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

