### PR TITLE
Add author revalidation hooks

### DIFF
--- a/src/modules/authors/collection.ts
+++ b/src/modules/authors/collection.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from 'payload';
 import { anyone } from '../payload/access/anyone';
 import { editor } from '../payload/access/editor';
 import { slugField } from '../payload/fields/slug';
-import { revalidateDelete, revalidatePost } from '../posts/revalidate';
+import { revalidateAuthor, revalidateAuthorDelete } from './revalidate';
 
 export const Authors: CollectionConfig = {
 	slug: 'authors',
@@ -13,8 +13,8 @@ export const Authors: CollectionConfig = {
 		delete: editor,
 	},
 	hooks: {
-		afterChange: [revalidatePost],
-		afterDelete: [revalidateDelete],
+		afterChange: [revalidateAuthor],
+		afterDelete: [revalidateAuthorDelete],
 	},
 	labels: {
 		singular: 'Autore',

--- a/src/modules/authors/revalidate.ts
+++ b/src/modules/authors/revalidate.ts
@@ -1,0 +1,45 @@
+import type { Author } from '@payload-types';
+
+import { revalidateTag } from 'next/cache';
+import type {
+	CollectionAfterChangeHook,
+	CollectionAfterDeleteHook,
+} from 'payload';
+
+export const revalidateAuthor: CollectionAfterChangeHook<Author> = ({
+	doc,
+	req: { payload, context },
+}) => {
+	if (context.disableRevalidate) {
+		return doc;
+	}
+
+	payload.logger.info(`Revalidating author: ${doc.slug}`);
+
+	if (doc.slug) {
+		revalidateTag(`authors_${doc.slug}`, {});
+	}
+
+	revalidateTag('authors', {});
+
+	return doc;
+};
+
+export const revalidateAuthorDelete: CollectionAfterDeleteHook<Author> = ({
+	doc,
+	req: { context, payload },
+}) => {
+	if (context.disableRevalidate) {
+		return doc;
+	}
+
+	payload.logger.info(`Revalidating deleted author: ${doc.slug}`);
+
+	if (doc.slug) {
+		revalidateTag(`authors_${doc.slug}`, {});
+	}
+
+	revalidateTag('authors', {});
+
+	return doc;
+};


### PR DESCRIPTION
## Summary
- Add dedicated revalidation hooks for the authors collection on change and delete.
- Revalidate both the collection tag (`authors`) and the per-author slug tag when a slug is present.
- Preserve the existing `disableRevalidate` bypass and add logging for author mutations.

## Testing
- Not run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds author-specific revalidation hooks so the authors list and individual author pages stay fresh on create, update, and delete. Keeps the `disableRevalidate` bypass and adds mutation logging.

- **New Features**
  - Added `revalidateAuthor` (afterChange) and `revalidateAuthorDelete` (afterDelete) hooks on the `authors` collection.
  - Revalidates `authors` and `authors_{slug}` tags via `revalidateTag` from `next/cache` when a slug exists.
  - Centralized logic in `src/modules/authors/revalidate.ts` and updated the collection to use it.

<sup>Written for commit e48a01fce14e9a5bd8554386917055f7c63ed3b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

