### PR TITLE
Remove collection-level cache tag from document lookup

### DIFF
--- a/src/modules/utilities/getDocument.ts
+++ b/src/modules/utilities/getDocument.ts
@@ -23,7 +23,6 @@ export async function getDocument({
 	'use cache';
 	cacheLife('max');
 	cacheTag(`${collection}_${slug}`);
-	cacheTag(collection);
 
 	const payload = await getPayload({ config: configPromise });
 	const result = await payload.find({


### PR DESCRIPTION
## Summary
- Remove the collection-level cache tag from `getDocument` so document lookups only tag the specific collection/slug pair.
- Reduce unnecessary cache invalidation scope for document fetches.

## Testing
- Not run (change is a one-line cache tag removal).
- Reviewed the diff to confirm only `src/modules/utilities/getDocument.ts` was changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrow cache tagging in `getDocument` by removing the collection-level tag so lookups only tag a specific `${collection}_${slug}`. This reduces unnecessary cache invalidation across entire collections.

<sup>Written for commit 94d8ee56e9052ad4c318e2c6227545bb17ec5b2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

