### PR TITLE
style: refine event page responsive layout and typography

### DIFF
--- a/src/modules/components/EventCard.tsx
+++ b/src/modules/components/EventCard.tsx
@@ -99,7 +99,7 @@ export default async function EventCard({
 				</div>
 			) : (
 				<div className='flex flex-col gap-2'>
-					<div className='flex px-1 items-center justify-between gap-0'>
+					<div className='flex flex-col gap-2 px-1 items-start justify-between '>
 						<p className='font-greed h-fit transition-colors duration-500 group-hover:bg-rosso-500 text-base font-bold uppercase '>
 							{dateLabel}
 						</p>

--- a/src/modules/events/components/EventContentSection.tsx
+++ b/src/modules/events/components/EventContentSection.tsx
@@ -19,7 +19,7 @@ export async function EventContentSection({
 
 	return (
 		<section className='px-5 py-15 md:py-20 lg:px-10 xl:px-20'>
-			<div className='grid pl-0 md:px-20 grid-cols-1 gap-8 lg:grid-cols-[3fr_2fr]'>
+			<div className='grid md:pl-30  md:pr-20 grid-cols-1 gap-8 lg:grid-cols-[3fr_2fr]'>
 				{/* Left: Content blocks */}
 				<div>
 					{event.content && event.content.length > 0 && (

--- a/src/modules/events/components/EventHero.tsx
+++ b/src/modules/events/components/EventHero.tsx
@@ -24,18 +24,18 @@ export function EventHero({
 	const bookingLabel = event.bookingLabel || 'Eventbrite';
 
 	return (
-		<section className='px-5 flex  flex-col md:flex-row pt-20 md:pt-24 pb-10 lg:px-10 xl:px-20'>
-			<div className='w-30 pb-4 pt-0.5 md:pb-0'>
+		<section className='px-5 flex flex-col md:flex-row pt-18 md:pt-24 pb-10 lg:px-10 xl:px-20'>
+			<div className='w-24 md:w-30 pb-4 pt-0.5 md:pb-0'>
 				<Link
 					aria-label={backLabel}
-					className='flex size-12 items-center justify-center rounded-[14px] border-2 border-black transition-colors hover:bg-black/5'
+					className='flex size-10 md:size-12 items-center justify-center rounded-[14px] border-2 border-black transition-colors hover:bg-black/5'
 					href={backHref}
 				>
 					<ArrowLeft />
 				</Link>
 			</div>
 
-			<div className=' items-start gap-4 md:gap-8 flex flex-col md:flex-row'>
+			<div className='w-full items-start gap-4 md:gap-8 flex flex-col md:flex-row'>
 				{/* Cover Image */}
 				{image && (
 					<div className='aspect-4/5 max-h-160 overflow-hidden rounded-4xl'>
@@ -54,7 +54,7 @@ export function EventHero({
 				{/* Title, Organizer, Booking, Links */}
 				<div className='flex flex-col pt-1 justify-between h-full gap-1'>
 					<div className='flex gap-1 flex-col'>
-						<h1 className='font-tagada text-4xl md:text-5xl text-balance tracking-wide lg:text-7xl'>
+						<h1 className='font-tagada text-4xl md:text-5xl text-balance tracking-wide lg:text-6xl xl:text-7xl'>
 							{event.title}
 						</h1>
 

--- a/src/modules/events/components/EventProgramSection.tsx
+++ b/src/modules/events/components/EventProgramSection.tsx
@@ -21,8 +21,8 @@ export function EventProgramSection({
 				{locale === 'it' ? 'Programma' : 'Program'}
 			</h2>
 			{Array.from(subEventGroups.entries()).map(([label, labelEvents]) => (
-				<div className='mb-12 last:mb-0 md:px-25' key={label}>
-					<h3 className='mb-4 font-greed text-2xl font-bold'>
+				<div className='mb-12  last:mb-0 md:px-25' key={label}>
+					<h3 className='mb-4 bg-rosso-500 px-1 font-greed text-xl md:text-2xl font-bold'>
 						{getLabelDisplayName(label, locale)}
 					</h3>
 					<div className='grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3'>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refines the event page responsive layout and type scale to improve mobile readability and align spacing across sections.

- **Refactors**
  - EventHero: smaller back button on mobile, reduced top padding, full-width content, and tuned title scale (lg 6xl, xl 7xl).
  - EventContentSection: updated grid padding to md:pl-30 and md:pr-20 for better alignment.
  - EventProgramSection: added `bg-rosso-500` label highlight and responsive heading size (text-xl → md:text-2xl).
  - EventCard: stacks metadata vertically and left-aligns on small screens for clearer layout.

<sup>Written for commit bf97e56a386ec11244da4ae8e44e7eb311cddb0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

