### PR TITLE
fix: contain event page content within mobile viewport

### DIFF
--- a/src/modules/editor/component.tsx
+++ b/src/modules/editor/component.tsx
@@ -123,7 +123,7 @@ const jsxConverters: JSXConvertersFunction<NodeTypes> = ({
 					return (
 						<h1
 							className={cn(
-								'font-ghost varW600 uppercase scroll-mt-48 md:text-5xl text-4xl lg:text-6xl font-bold mb-6'
+								'font-ghost varW600 uppercase wrap-break-word scroll-mt-48 md:text-5xl text-3xl lg:text-6xl font-bold mb-6'
 							)}
 						>
 							{children}
@@ -133,7 +133,7 @@ const jsxConverters: JSXConvertersFunction<NodeTypes> = ({
 					return (
 						<h2
 							className={cn(
-								'font-ghost varW600 uppercase scroll-mt-48 md:text-4xl text-3xl lg:text-5xl'
+								'font-ghost varW600 uppercase wrap-break-word scroll-mt-48 md:text-4xl text-2xl lg:text-5xl'
 							)}
 						>
 							{children}
@@ -143,7 +143,7 @@ const jsxConverters: JSXConvertersFunction<NodeTypes> = ({
 					return (
 						<h3
 							className={cn(
-								'font-ghost varW600 uppercase scroll-mt-48 md:text-3xl text-2xl lg:text-4xl font-semibold mb-4'
+								'font-ghost varW600 uppercase wrap-break-word scroll-mt-48 md:text-3xl text-xl lg:text-4xl font-semibold mb-4'
 							)}
 						>
 							{children}
@@ -217,7 +217,7 @@ export default function RichText(props: Props) {
 						enableProse,
 				},
 				className,
-				'flex flex-col gap-2.5 md:gap-5',
+				'flex flex-col min-w-0 max-w-full wrap-anywhere gap-2.5 md:gap-5',
 				'font-greed tracking-[0.01em] text-xl md:text-2xl'
 			)}
 			converters={jsxConverters}

--- a/src/modules/events/components/EventContentSection.tsx
+++ b/src/modules/events/components/EventContentSection.tsx
@@ -21,7 +21,7 @@ export async function EventContentSection({
 		<section className='px-5 py-15 md:py-20 lg:px-10 xl:px-20'>
 			<div className='grid md:pl-30  md:pr-20 grid-cols-1 gap-8 lg:grid-cols-[3fr_2fr]'>
 				{/* Left: Content blocks */}
-				<div>
+				<div className='min-w-0'>
 					{event.content && event.content.length > 0 && (
 						<>
 							<h2 className='mb-4 font-greed text-4xl font-bold'>
@@ -37,17 +37,17 @@ export async function EventContentSection({
 				</div>
 
 				{/* Right: Date + Location sidebar */}
-				<div className='flex flex-col items-start md:items-end gap-4 md:gap-8'>
+				<div className='flex flex-col min-w-0 items-start md:items-end gap-4 md:gap-8'>
 					<div className='space-y-8 md:space-y-20'>
 						{/* Date/Time */}
 						<div>
 							<div className='mb-2 w-fit px-1 font-bold bg-rosso-500'>
 								{t('when')}
 							</div>
-							<p className='font-ghost text-4xl varW600 uppercase tracking-wide'>
+							<p className='font-ghost text-2xl md:text-4xl varW600 uppercase tracking-wide'>
 								{startDateTime.date} {startDateTime.time}
 							</p>
-							<p className='font-ghost text-4xl varW600 uppercase tracking-wide'>
+							<p className='font-ghost text-2xl md:text-4xl varW600 uppercase tracking-wide'>
 								— {isMultiDay && `${endDateTime.date} `}
 								{endDateTime.time}
 							</p>
@@ -61,7 +61,7 @@ export async function EventContentSection({
 								</div>
 								{event.address.googleMapsUrl ? (
 									<a
-										className='font-ghost text-4xl varW600 hover:no-underline underline decoration-1 underline-offset-4 uppercase tracking-wide'
+										className='font-ghost text-2xl md:text-4xl varW600 hover:no-underline underline decoration-1 underline-offset-4 uppercase tracking-wide'
 										href={event.address.googleMapsUrl}
 										rel='noopener noreferrer'
 										target='_blank'
@@ -69,7 +69,7 @@ export async function EventContentSection({
 										{event.address.location}
 									</a>
 								) : (
-									<p className='font-ghost text-4xl varW600 uppercase tracking-wide'>
+									<p className='font-ghost text-2xl md:text-4xl varW600 uppercase tracking-wide'>
 										{event.address.location}
 									</p>
 								)}

--- a/src/modules/events/components/EventHero.tsx
+++ b/src/modules/events/components/EventHero.tsx
@@ -35,7 +35,7 @@ export function EventHero({
 				</Link>
 			</div>
 
-			<div className='w-full items-start gap-4 md:gap-8 flex flex-col md:flex-row'>
+			<div className='w-full min-w-0 items-start gap-4 md:gap-8 flex flex-col md:flex-row'>
 				{/* Cover Image */}
 				{image && (
 					<div className='aspect-4/5 max-h-160 overflow-hidden rounded-4xl'>
@@ -52,7 +52,7 @@ export function EventHero({
 				)}
 
 				{/* Title, Organizer, Booking, Links */}
-				<div className='flex flex-col pt-1 justify-between h-full gap-1'>
+				<div className='flex flex-col min-w-0 pt-1 justify-between h-full gap-1'>
 					<div className='flex gap-1 flex-col'>
 						<h1 className='font-tagada text-4xl md:text-5xl text-balance tracking-wide lg:text-6xl xl:text-7xl'>
 							{event.title}


### PR DESCRIPTION
Rich text content and wide flex children were pushing the event detail page past the viewport on mobile. Add min-w-0 to flex/grid items so they shrink to their column, wrap-anywhere on the rich text container, and scale down the date/location typography on small screens.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile overflow on the event detail page by keeping content within the viewport and ensuring long text wraps correctly.

- **Bug Fixes**
  - Added `min-w-0` to flex/grid children in EventHero and EventContentSection so columns shrink on small screens.
  - Enabled `wrap-anywhere` on the rich text container and `wrap-break-word` on headings; set `max-w-full` to prevent spillover.
  - Scaled down heading and date/location typography on small screens.

<sup>Written for commit 262dee046724cdd26aea4cabde316fbdee6412f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

