### PR TITLE
feat: show page globals to editors and admins in admin sidebar

### DIFF
--- a/src/modules/settings/about.ts
+++ b/src/modules/settings/about.ts
@@ -11,7 +11,7 @@ export const About: GlobalConfig = {
 	},
 	admin: {
 		group: 'Pages',
-		hidden: true,
+		hidden: ({ user }) => user?.role !== 'editor' && user?.role !== 'admin',
 	},
 	hooks: {
 		afterChange: [revalidateGlobal],

--- a/src/modules/settings/goccia.ts
+++ b/src/modules/settings/goccia.ts
@@ -7,7 +7,7 @@ export const Goccia: GlobalConfig = {
 	label: 'La Goccia',
 	admin: {
 		group: 'Pages',
-		hidden: true,
+		hidden: ({ user }) => user?.role !== 'editor' && user?.role !== 'admin',
 	},
 	access: {
 		read: editor,

--- a/src/modules/settings/home.ts
+++ b/src/modules/settings/home.ts
@@ -25,7 +25,7 @@ export const Home: GlobalConfig = {
 	slug: 'home',
 	admin: {
 		group: 'Pages',
-		hidden: true,
+		hidden: ({ user }) => user?.role !== 'editor' && user?.role !== 'admin',
 	},
 	access: {
 		read: editor,

--- a/src/modules/settings/project.ts
+++ b/src/modules/settings/project.ts
@@ -9,7 +9,7 @@ export const Project: GlobalConfig = {
 	label: 'Progetto',
 	admin: {
 		group: 'Pages',
-		hidden: true,
+		hidden: ({ user }) => user?.role !== 'editor' && user?.role !== 'admin',
 	},
 	access: {
 		read: editor,


### PR DESCRIPTION
Replace hidden: true with a role-based function so editors and admins can see the Pages group (Home, Progetto, La Goccia, Chi Siamo) in the Payload admin sidebar. Regular users still cannot see them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the Pages group (Home, Progetto, La Goccia, Chi Siamo) in the Payload admin sidebar for editors and admins. Replaced static admin.hidden: true with a role-based function; non-editor/admin users still won't see these globals.

<sup>Written for commit 7ad54ba1e3681bf36dbcdb919d6f2cd5e9b80f68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

