### PR TITLE
Fix/times

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,11 @@
+// Project tasks configuration. See https://zed.dev/docs/tasks for documentation.
+[
+  {
+    "label": "Open repo on GitHub",
+    "command": "gh",
+    "args": ["browse"],
+    "reveal": "never",
+    "hide": "always",
+    "use_new_terminal": false
+  }
+]

--- a/src/modules/components/EventCard.tsx
+++ b/src/modules/components/EventCard.tsx
@@ -2,7 +2,7 @@ import type { Event, Image as ImageType } from '@payload-types';
 import { getLocale } from 'next-intl/server';
 import { Link } from '@/i18n/routing';
 import { getEventHref } from '@/modules/events/paths';
-import { formatEventDateTime } from '@/modules/events/utils';
+import { formatEventDateRange } from '@/modules/events/utils';
 import { CustomImage } from './CustomImage';
 
 type EventCardVariant = 'default' | 'compact';
@@ -13,35 +13,15 @@ interface EventCardProps {
 	variant?: EventCardVariant;
 }
 
-function formatEventDateLong(timestamp: string, locale: string): string {
-	const date = new Date(timestamp);
-	const loc = locale === 'it' ? 'it-IT' : 'en-GB';
-	const dateLabel = date.toLocaleDateString(loc, {
-		day: 'numeric',
-		month: 'long',
-		year: 'numeric',
-	});
-	const timeLabel = date.toLocaleTimeString(loc, {
-		hour: '2-digit',
-		minute: '2-digit',
-		hour12: false,
-	});
-	return `${dateLabel} · ${timeLabel}`;
-}
-
 function getDateLabel(
 	startDate: string | null | undefined,
-	locale: string,
-	isCompact: boolean
+	endDate: string | null | undefined,
+	locale: string
 ): string {
 	if (!startDate) {
 		return '—';
 	}
-	if (!isCompact) {
-		return formatEventDateLong(startDate, locale);
-	}
-	const { date, time } = formatEventDateTime(startDate, locale);
-	return `${date} · ${time}`;
+	return formatEventDateRange(startDate, endDate, locale);
 }
 
 export default async function EventCard({
@@ -72,7 +52,11 @@ export default async function EventCard({
 		? undefined
 		: '(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 33vw';
 
-	const dateLabel = getDateLabel(event.when.startDate, locale, isCompact);
+	const dateLabel = getDateLabel(
+		event.when.startDate,
+		event.when.endDate,
+		locale
+	);
 
 	return (
 		<Link className={wrapperClass} href={eventHref} locale={locale}>
@@ -89,21 +73,21 @@ export default async function EventCard({
 			) : null}
 
 			{isCompact ? (
-				<div className='flex justify-between px-1'>
-					<p className='font-greed h-fit uppercase transition-colors duration-500 group-hover:bg-rosso-500 text-balance text-base font-bold '>
-						{event.title}
-					</p>
-					<p className='font-greed h-fit uppercase transition-colors duration-500 group-hover:bg-rosso-500 text-base font-bold '>
+				<div className='flex flex-col gap-1 px-1'>
+					<p className='font-greed h-fit uppercase transition-colors duration-500 group-hover:bg-rosso-500 px-1 w-fit text-base font-bold '>
 						{dateLabel}
+					</p>
+					<p className='font-greed h-fit uppercase transition-colors duration-500 group-hover:bg-rosso-500 px-1 w-fit text-balance text-base font-bold '>
+						{event.title}
 					</p>
 				</div>
 			) : (
 				<div className='flex flex-col gap-2'>
 					<div className='flex flex-col gap-2 px-1 items-start justify-between '>
-						<p className='font-greed h-fit transition-colors duration-500 group-hover:bg-rosso-500 text-base font-bold uppercase '>
+						<p className='font-greed h-fit transition-colors duration-500 group-hover:bg-rosso-500 w-fit text-base font-bold uppercase '>
 							{dateLabel}
 						</p>
-						<p className='font-greed h-fit transition-colors duration-500 group-hover:bg-rosso-500 text-base font-bold uppercase '>
+						<p className='font-greed h-fit w-fit transition-colors duration-500 group-hover:bg-rosso-500 text-base font-bold uppercase '>
 							{event.address?.location ?? ''}
 						</p>
 					</div>

--- a/src/modules/components/HeaderArticle.tsx
+++ b/src/modules/components/HeaderArticle.tsx
@@ -27,6 +27,7 @@ export default function HeaderArticle({
 							day: 'numeric',
 							month: 'long',
 							year: 'numeric',
+							timeZone: 'Europe/Rome',
 						})}
 					</li>
 				</ul>

--- a/src/modules/events/utils.ts
+++ b/src/modules/events/utils.ts
@@ -13,13 +13,52 @@ export function formatEventDateTime(
 			day: '2-digit',
 			month: '2-digit',
 			year: 'numeric',
+			timeZone: 'Europe/Rome',
 		}).format(date),
 		time: new Intl.DateTimeFormat(loc, {
 			hour: '2-digit',
 			minute: '2-digit',
 			hour12: false,
+			timeZone: 'Europe/Rome',
 		}).format(date),
 	};
+}
+
+export function formatEventDateRange(
+	startDate: string,
+	endDate: string | null | undefined,
+	locale: string
+): string {
+	const loc = locale === 'it' ? 'it-IT' : 'en-GB';
+	const dateFmt = new Intl.DateTimeFormat(loc, {
+		day: 'numeric',
+		month: 'long',
+		year: 'numeric',
+		timeZone: 'Europe/Rome',
+	});
+	const timeFmt = new Intl.DateTimeFormat(loc, {
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: false,
+		timeZone: 'Europe/Rome',
+	});
+
+	const start = new Date(startDate);
+	const startDateLabel = dateFmt.format(start);
+	const startTimeLabel = timeFmt.format(start);
+
+	if (!endDate) {
+		return `${startDateLabel} ${startTimeLabel}`;
+	}
+
+	const end = new Date(endDate);
+	const endDateLabel = dateFmt.format(end);
+	const endTimeLabel = timeFmt.format(end);
+
+	if (startDateLabel === endDateLabel) {
+		return `${startDateLabel} ${startTimeLabel} – ${endTimeLabel}`;
+	}
+	return `${startDateLabel} ${startTimeLabel} – ${endDateLabel} ${endTimeLabel}`;
 }
 
 export function groupSubEventsByLabel(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect event times by enforcing the Europe/Rome timezone and adds clear start–end date ranges to event cards. Also updates the compact EventCard layout for better readability.

- **New Features**
  - Show event date ranges: single-day as "date HH:MM – HH:MM", multi-day as "date HH:MM – date HH:MM".
  - Added `formatEventDateRange()` and switched `EventCard` to use it; handles missing end dates.

- **Bug Fixes**
  - Force `Europe/Rome` timezone for all displayed dates/times in events and articles.

<sup>Written for commit 247f98bd0578a89dc5566e3bf0a0d67a2c47fd27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

