### PR TITLE
Harden preview validation and local sync workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,17 @@ CRON_SECRET=
 DATABASE_URL="file:payload.sqlite"
 # DATABASE_AUTH_TOKEN=
 
+# Production/source database for scripts/pull-prod.sh only.
+# Deployed runtime may use TURSO_DATABASE_URL only when DATABASE_URL is unset.
+TURSO_DATABASE_URL=
+TURSO_AUTH_TOKEN=
+
+# Production/source media for scripts/sync-media.sh only.
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=
+
 # Minio (S3 Storage)
 S3_ENDPOINT=http://localhost:9000 # Minio endpoint
 S3_BUCKET=media # You need to create this bucket in Minio

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 
 *.db
 *.sqlite
+*.sqlite-journal
+*.sqlite-shm
+*.sqlite-wal
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,8 +1,43 @@
 # La Goccia
 
-- Nextjs 15
+- Nextjs 16
 - PayloadCMS 3
 - Tailwind 4
 - shadcn/ui
 - Turso
 - R2
+
+## Local Data Safety
+
+Local app execution, migrations, builds, tests, and uploads must target local
+SQLite and local MinIO.
+
+- `DATABASE_URL` is the primary runtime database URL. Use
+	`DATABASE_URL=file:payload.sqlite` for local dev, builds, and tests.
+- `TURSO_DATABASE_URL` is the production/source database URL. It is read by
+	`scripts/pull-prod.sh`, and deployed runtime may use it only when
+	`DATABASE_URL` is not set.
+- `R2_*` credentials are source-only media credentials for
+	`scripts/sync-media.sh`; Payload runtime must use `S3_*` instead.
+- `S3_*` config is the runtime upload target. Local uploads must use
+	`S3_ENDPOINT=http://localhost:9000`.
+
+Fresh local dataset workflow:
+
+```bash
+pnpm db:up
+pnpm pull:prod
+pnpm build
+```
+
+Full local verification:
+
+```bash
+pnpm db:up
+pnpm pull:prod
+pnpm payload migrate
+pnpm test
+pnpm typecheck
+pnpm exec biome check .
+pnpm build
+```

--- a/package.json
+++ b/package.json
@@ -5,13 +5,16 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "pnpm payload migrate && next build",
+    "build": "pnpm payload migrate && pnpm build:next",
+    "build:next": "next build",
     "dev": "pnpm payload migrate && next dev --turbopack",
     "devsafe": "pnpm payload migrate && rm -rf .next && next dev",
     "generate:importmap": "payload generate:importmap",
     "generate:types": "payload generate:types",
     "fix": "pnpm dlx ultracite fix",
     "typecheck": "next typegen && tsc --noEmit",
+    "test": "vitest run",
+    "verify": "pnpm typecheck && pnpm exec biome check . && pnpm build",
     "payload": "payload",
     "start": "next start",
     "db:up": "docker compose -f docker-compose.db.yml up -d",
@@ -68,7 +71,8 @@
     "lint-staged": "^16.4.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",
-    "ultracite": "7.1.4"
+    "ultracite": "7.1.4",
+    "vitest": "^4.1.5"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,jsonc,css,scss,md,mdx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       ultracite:
         specifier: 7.1.4
         version: 7.1.4
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(happy-dom@20.8.9)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -470,8 +473,17 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -1430,6 +1442,12 @@ packages:
   '@mux/playback-core@0.33.3':
     resolution: {integrity: sha512-96HKZoK3TFUvDU3sDiAei/nAV4+Xx0JCiIjJNcl/ZcAjObL0daHQmM+zgtjvU2T6L5zEaGPxnX3OTfI4OogWzg==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
@@ -1490,6 +1508,9 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -1934,6 +1955,104 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
 
@@ -2148,6 +2267,9 @@ packages:
   '@smithy/uuid@1.1.2':
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@svta/cml-608@1.0.1':
     resolution: {integrity: sha512-Y/Ier9VPUSOBnf0bJqdDyTlPrt4dDB+jk5mYHa1bnD2kcRl8qn7KkW3PRuj4w1aVN+BS2eHmsLxodt7P2hylUg==}
@@ -2406,14 +2528,23 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
   '@types/busboy@1.5.4':
     resolution: {integrity: sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -2485,6 +2616,35 @@ packages:
   '@vimeo/player@2.29.0':
     resolution: {integrity: sha512-9JjvjeqUndb9otCCFd0/+2ESsLk7VkDE6sxOBy9iy2ukezuQbplVRi+g9g59yAurKofbmTi/KcKxBGO/22zWRw==}
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -2515,6 +2675,10 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -2597,6 +2761,10 @@ packages:
     peerDependencies:
       react: '>=17.0.0'
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -2665,6 +2833,9 @@ packages:
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -2904,6 +3075,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -2937,6 +3111,9 @@ packages:
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -2947,6 +3124,10 @@ packages:
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
@@ -3637,6 +3818,9 @@ packages:
   object-to-formdata@4.5.1:
     resolution: {integrity: sha512-QiM9D0NiU5jV6J6tjE1g7b4Z2tcUnKs1OPUi4iMb2zH+7jwlcUrASghgkFk9GtzqNNq8rTQJtT8AzjBAvLoNMw==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -3922,6 +4106,11 @@ packages:
   robust-predicates@2.0.4:
     resolution: {integrity: sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -3968,6 +4157,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -4021,8 +4213,14 @@ packages:
   spotify-audio-element@1.0.4:
     resolution: {integrity: sha512-QdKrJPkYCzaNwwz2vN2eDGyoW0KmQFmnwVprB41mpMzj4qujbqr6pegEchQeTn0b5PceKiLoVu0pp2QDpTcWnw==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
@@ -4109,6 +4307,9 @@ packages:
   tiktok-video-element@0.1.2:
     resolution: {integrity: sha512-w6TboLm236XJKKiIXIhCbYCnUxbixBbaAoty0etaEAZ/2kHkVIdfZdv2oouMU/HGMsWCHI/VjQ3wU3MJ+s192Q==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -4119,6 +4320,10 @@ packages:
 
   tinyqueue@3.0.0:
     resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-no-case@1.0.2:
     resolution: {integrity: sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg==}
@@ -4265,6 +4470,90 @@ packages:
   vimeo-video-element@1.7.1:
     resolution: {integrity: sha512-GSlKdqPoa133f2YbuO4JObPWuZ/3+ShIesXhpqtli4p0+STL4YsZ73ixolLK49+VHkOFMfnjeN9Cghh+bGjkhA==}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   weakmap-polyfill@2.0.4:
     resolution: {integrity: sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==}
     engines: {node: '>=8.10.0'}
@@ -4290,6 +4579,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wistia-video-element@1.3.6:
@@ -4963,7 +5257,23 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5788,6 +6098,13 @@ snapshots:
       hls.js: 1.6.15
       mux-embed: 5.18.0
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@neon-rs/load@0.0.4': {}
 
   '@next/env@15.5.15': {}
@@ -5817,6 +6134,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
+
+  '@oxc-project/types@0.127.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -6386,6 +6705,57 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
   '@schummar/icu-type-parser@1.21.5': {}
 
   '@smithy/chunked-blob-reader-native@4.2.3':
@@ -6721,6 +7091,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@svta/cml-608@1.0.1': {}
 
   '@svta/cml-cmcd@1.0.1(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)':
@@ -6905,6 +7277,11 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.8
@@ -6913,9 +7290,16 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -6985,6 +7369,47 @@ snapshots:
       native-promise-only: 0.8.1
       weakmap-polyfill: 2.0.4
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn@8.16.0: {}
 
   ajv@8.18.0:
@@ -7012,6 +7437,8 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
 
   atomic-sleep@1.0.0: {}
 
@@ -7085,6 +7512,8 @@ snapshots:
     dependencies:
       react: 19.2.5
 
+  chai@6.2.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -7145,6 +7574,8 @@ snapshots:
       simple-wcswidth: 1.1.2
 
   convert-source-map@1.9.0: {}
+
+  convert-source-map@2.0.0: {}
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -7303,6 +7734,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.0.0: {}
+
   esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
       debug: 4.4.3
@@ -7404,6 +7837,10 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
@@ -7411,6 +7848,8 @@ snapshots:
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
+
+  expect-type@1.3.0: {}
 
   fast-copy@3.0.2: {}
 
@@ -8228,6 +8667,8 @@ snapshots:
 
   object-to-formdata@4.5.1: {}
 
+  obug@2.1.1: {}
+
   on-exit-leak-free@2.1.2: {}
 
   once@1.4.0:
@@ -8575,6 +9016,27 @@ snapshots:
 
   robust-predicates@2.0.4: {}
 
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
   safe-buffer@5.2.1: {}
 
   safe-stable-stringify@2.5.0: {}
@@ -8638,6 +9100,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-wcswidth@1.1.2: {}
@@ -8680,7 +9144,11 @@ snapshots:
 
   spotify-audio-element@1.0.4: {}
 
+  stackback@0.0.2: {}
+
   state-local@1.0.7: {}
+
+  std-env@4.1.0: {}
 
   stream-browserify@3.0.0:
     dependencies:
@@ -8752,6 +9220,8 @@ snapshots:
 
   tiktok-video-element@0.1.2: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
@@ -8760,6 +9230,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinyqueue@3.0.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   to-no-case@1.0.2: {}
 
@@ -8896,6 +9368,50 @@ snapshots:
       '@vimeo/player': 2.29.0
       media-played-ranges-mixin: 0.1.0
 
+  vite@8.0.10(@types/node@25.6.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.25.12
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      sass: 1.77.4
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vitest@4.1.5(@types/node@25.6.0)(happy-dom@20.8.9)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      happy-dom: 20.8.9
+    transitivePeerDependencies:
+      - msw
+
   weakmap-polyfill@2.0.4: {}
 
   web-streams-polyfill@3.3.3: {}
@@ -8916,6 +9432,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wistia-video-element@1.3.6:
     dependencies:

--- a/scripts/pull-prod.sh
+++ b/scripts/pull-prod.sh
@@ -8,7 +8,11 @@ if [ -f .env ]; then
 	set +a
 fi
 
-# Pull production database and media to local environment
+# Pull production database and media to local environment.
+# Safety contract:
+#   - Reads from TURSO_DATABASE_URL.
+#   - Writes only the local payload.sqlite file.
+#   - Then calls scripts/sync-media.sh, which writes only to local MinIO.
 # Prerequisites:
 #   brew install tursodatabase/tap/turso
 #   brew install minio/stable/mc
@@ -23,6 +27,8 @@ for var in TURSO_DATABASE_URL R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KE
 	fi
 done
 
+echo "==> Read-only source: TURSO_DATABASE_URL"
+echo "==> Local database destination: payload.sqlite"
 echo "==> Dumping production database..."
 rm -f payload.sqlite
 turso db shell "$TURSO_DATABASE_URL" .dump > dump.sql
@@ -31,8 +37,8 @@ rm dump.sql
 echo "Database saved to payload.sqlite"
 
 echo ""
-echo "==> Syncing media from R2..."
+echo "==> Syncing media from R2 into local MinIO..."
 bash scripts/sync-media.sh
 
 echo ""
-echo "==> Done. Run 'pnpm dev' to start."
+echo "==> Done. Use DATABASE_URL=file:payload.sqlite before running app/build locally."

--- a/scripts/sync-media.sh
+++ b/scripts/sync-media.sh
@@ -8,11 +8,15 @@ if [ -f .env ]; then
 	set +a
 fi
 
-# Sync media files from Cloudflare R2 (production) to local MinIO
+# Sync media files from Cloudflare R2 (production) to local MinIO.
+# Safety contract:
+#   - Reads from the r2prod alias backed by R2_* credentials.
+#   - Writes only to the local MinIO alias at http://localhost:9000.
+#   - Does not mirror back to r2prod.
 # Prerequisites: brew install minio/stable/mc
 # Required env vars: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET
 
-for var in R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_BUCKET S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY S3_BUCKET; do
+for var in R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_BUCKET S3_ENDPOINT S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY S3_BUCKET; do
 	if [ -z "${!var:-}" ]; then
 		echo "Error: $var is not set"
 		exit 1
@@ -20,14 +24,24 @@ for var in R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_BUCKET S3_ACCE
 done
 
 R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+LOCAL_ENDPOINT="${S3_ENDPOINT}"
 LOCAL_ALIAS="local"
 R2_ALIAS="r2prod"
+
+if [ "$LOCAL_ENDPOINT" != "http://localhost:9000" ]; then
+	echo "Error: refusing media sync because S3_ENDPOINT is not http://localhost:9000"
+	echo "Destination endpoint was: $LOCAL_ENDPOINT"
+	exit 1
+fi
+
+echo "==> Read-only media source: ${R2_ALIAS}/${R2_BUCKET}"
+echo "==> Local media destination: ${LOCAL_ALIAS}/${S3_BUCKET} at ${LOCAL_ENDPOINT}"
 
 # Configure R2 remote
 mc alias set "$R2_ALIAS" "$R2_ENDPOINT" "$R2_ACCESS_KEY_ID" "$R2_SECRET_ACCESS_KEY"
 
 # Configure local MinIO (uses same S3_* credentials as docker-compose)
-mc alias set "$LOCAL_ALIAS" "http://localhost:9000" "$S3_ACCESS_KEY_ID" "$S3_SECRET_ACCESS_KEY"
+mc alias set "$LOCAL_ALIAS" "$LOCAL_ENDPOINT" "$S3_ACCESS_KEY_ID" "$S3_SECRET_ACCESS_KEY"
 
 # Ensure local bucket exists
 mc mb --ignore-existing "${LOCAL_ALIAS}/${S3_BUCKET}"

--- a/src/app/(frontend)/[locale]/error.tsx
+++ b/src/app/(frontend)/[locale]/error.tsx
@@ -1,17 +1,23 @@
 'use client';
 
+import { useEffect } from 'react';
+
 interface ErrorProps {
 	error: Error & { digest?: string };
 	reset: () => void;
 }
 
 export default function ErrorPage({ error, reset }: ErrorProps) {
+	useEffect(() => {
+		console.error('Route error', { digest: error.digest });
+	}, [error.digest]);
+
 	return (
 		<main className='min-h-screen flex items-center justify-center px-5'>
 			<div className='text-center space-y-4'>
 				<h1 className='text-2xl font-greed'>Something went wrong</h1>
 				<p className='text-gray-600'>
-					{error.message || 'An unexpected error occurred'}
+					An unexpected error occurred. Please try again.
 				</p>
 				<button
 					className='px-4 py-2 bg-black text-white rounded-lg hover:bg-gray-800 transition-colors'

--- a/src/app/(frontend)/next/preview/previewPathValidation.test.ts
+++ b/src/app/(frontend)/next/preview/previewPathValidation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { isValidPreviewPath } from './validatePreviewPath';
+
+describe('preview path validation', () => {
+	it('allows matching post preview paths', () => {
+		expect(
+			isValidPreviewPath({
+				collection: 'posts',
+				path: '/blog/a',
+				slug: 'a',
+			})
+		).toBe(true);
+	});
+
+	it('allows matching resource preview paths', () => {
+		expect(
+			isValidPreviewPath({
+				collection: 'resources',
+				path: '/risorse/a',
+				slug: 'a',
+			})
+		).toBe(true);
+	});
+
+	it('allows nested event paths with the slug as a full segment', () => {
+		expect(
+			isValidPreviewPath({
+				collection: 'events',
+				path: '/eventi/parent/child',
+				slug: 'child',
+			})
+		).toBe(true);
+	});
+
+	it('rejects collection and path mismatches', () => {
+		expect(
+			isValidPreviewPath({
+				collection: 'posts',
+				path: '/risorse/a',
+				slug: 'a',
+			})
+		).toBe(false);
+	});
+
+	it('rejects external URL-like paths', () => {
+		expect(
+			isValidPreviewPath({
+				collection: 'posts',
+				path: 'https://example.com/blog/a',
+				slug: 'a',
+			})
+		).toBe(false);
+		expect(
+			isValidPreviewPath({
+				collection: 'posts',
+				path: '/https:%2F%2Fexample.com/blog/a',
+				slug: 'a',
+			})
+		).toBe(false);
+	});
+
+	it('rejects traversal paths', () => {
+		expect(
+			isValidPreviewPath({
+				collection: 'posts',
+				path: '/blog/../admin',
+				slug: 'admin',
+			})
+		).toBe(false);
+	});
+});

--- a/src/app/(frontend)/next/preview/route.ts
+++ b/src/app/(frontend)/next/preview/route.ts
@@ -6,6 +6,7 @@ import type { AuthResult } from 'node_modules/payload/dist/auth/operations/auth'
 import type { CollectionSlug, PayloadRequest } from 'payload';
 import { getPayload } from 'payload';
 import { redirect } from '@/i18n/routing';
+import { isValidPreviewPath } from './validatePreviewPath';
 
 export async function GET(request: NextRequest) {
 	const payload = await getPayload({ config: configPromise });
@@ -30,8 +31,12 @@ export async function GET(request: NextRequest) {
 	if (!path.startsWith('/')) {
 		return new Response(
 			'This endpoint can only be used for relative previews',
-			{ status: 500 }
+			{ status: 400 }
 		);
+	}
+
+	if (!isValidPreviewPath({ collection, path, slug })) {
+		return new Response('Invalid preview path', { status: 400 });
 	}
 
 	let result: AuthResult | null = null;

--- a/src/app/(frontend)/next/preview/validatePreviewPath.ts
+++ b/src/app/(frontend)/next/preview/validatePreviewPath.ts
@@ -1,0 +1,70 @@
+const PROTOCOL_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
+const LEADING_SLASHES_PATTERN = /^\/+/;
+
+function decodePath(path: string): string | null {
+	try {
+		return decodeURIComponent(path);
+	} catch {
+		return null;
+	}
+}
+
+function hasUnsafePathSyntax(path: string): boolean {
+	const decodedPath = decodePath(path);
+
+	if (!decodedPath) {
+		return true;
+	}
+
+	if (!(path.startsWith('/') && decodedPath.startsWith('/'))) {
+		return true;
+	}
+
+	if (path.includes('//') || decodedPath.includes('//')) {
+		return true;
+	}
+
+	const segments = decodedPath.split('/').filter(Boolean);
+
+	if (segments.includes('..')) {
+		return true;
+	}
+
+	return PROTOCOL_PATTERN.test(
+		decodedPath.replace(LEADING_SLASHES_PATTERN, '')
+	);
+}
+
+export function isValidPreviewPath({
+	collection,
+	path,
+	slug,
+}: {
+	collection: string;
+	path: string;
+	slug: string;
+}): boolean {
+	if (hasUnsafePathSyntax(path)) {
+		return false;
+	}
+
+	const decodedPath = decodePath(path);
+
+	if (!decodedPath) {
+		return false;
+	}
+
+	switch (collection) {
+		case 'posts':
+			return decodedPath === `/blog/${slug}`;
+		case 'resources':
+			return decodedPath === `/risorse/${slug}`;
+		case 'events': {
+			const segments = decodedPath.split('/').filter(Boolean);
+
+			return segments[0] === 'eventi' && segments.includes(slug);
+		}
+		default:
+			return false;
+	}
+}

--- a/src/modules/authors/revalidate.ts
+++ b/src/modules/authors/revalidate.ts
@@ -5,6 +5,29 @@ import type {
 	CollectionAfterChangeHook,
 	CollectionAfterDeleteHook,
 } from 'payload';
+import {
+	collectionBaseTag,
+	collectionTag,
+	documentBaseTag,
+	documentTag,
+	localesForInvalidation,
+} from '@/modules/utilities/cacheTags';
+
+function revalidateAuthorTags(slug?: string | null) {
+	if (slug) {
+		revalidateTag(documentBaseTag('authors', slug), {});
+
+		for (const locale of localesForInvalidation) {
+			revalidateTag(documentTag('authors', slug, locale), {});
+		}
+	}
+
+	revalidateTag(collectionBaseTag('authors'), {});
+
+	for (const locale of localesForInvalidation) {
+		revalidateTag(collectionTag('authors', locale), {});
+	}
+}
 
 export const revalidateAuthor: CollectionAfterChangeHook<Author> = ({
 	doc,
@@ -16,11 +39,7 @@ export const revalidateAuthor: CollectionAfterChangeHook<Author> = ({
 
 	payload.logger.info(`Revalidating author: ${doc.slug}`);
 
-	if (doc.slug) {
-		revalidateTag(`authors_${doc.slug}`, {});
-	}
-
-	revalidateTag('authors', {});
+	revalidateAuthorTags(doc.slug);
 
 	return doc;
 };
@@ -35,11 +54,7 @@ export const revalidateAuthorDelete: CollectionAfterDeleteHook<Author> = ({
 
 	payload.logger.info(`Revalidating deleted author: ${doc.slug}`);
 
-	if (doc.slug) {
-		revalidateTag(`authors_${doc.slug}`, {});
-	}
-
-	revalidateTag('authors', {});
+	revalidateAuthorTags(doc.slug);
 
 	return doc;
 };

--- a/src/modules/events/detail.tsx
+++ b/src/modules/events/detail.tsx
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import configPromise from '@payload-config';
 import type { Event } from '@payload-types';
 import { draftMode } from 'next/headers';

--- a/src/modules/events/revalidate.ts
+++ b/src/modules/events/revalidate.ts
@@ -5,6 +5,32 @@ import type {
 	CollectionAfterChangeHook,
 	CollectionAfterDeleteHook,
 } from 'payload';
+import {
+	collectionBaseTag,
+	collectionTag,
+	documentBaseTag,
+	documentTag,
+	localesForInvalidation,
+} from '@/modules/utilities/cacheTags';
+
+function revalidateEventDocumentTags(slug?: string | null) {
+	if (!slug) {
+		return;
+	}
+
+	revalidateTag(documentBaseTag('events', slug), {});
+	for (const locale of localesForInvalidation) {
+		revalidateTag(documentTag('events', slug, locale), {});
+	}
+}
+
+function revalidateEventListTags() {
+	revalidateTag(collectionBaseTag('events'), {});
+
+	for (const locale of localesForInvalidation) {
+		revalidateTag(collectionTag('events', locale), {});
+	}
+}
 
 export const revalidateEvent: CollectionAfterChangeHook<Event> = async ({
 	doc,
@@ -17,8 +43,8 @@ export const revalidateEvent: CollectionAfterChangeHook<Event> = async ({
 	if (doc._status === 'published') {
 		payload.logger.info(`Revalidating event: ${doc.slug}`);
 
-		revalidateTag(`events_${doc.slug}`, {});
-		revalidateTag('events', {});
+		revalidateEventDocumentTags(doc.slug);
+		revalidateEventListTags();
 
 		const children = await payload.find({
 			collection: 'events',
@@ -30,7 +56,7 @@ export const revalidateEvent: CollectionAfterChangeHook<Event> = async ({
 
 		for (const child of children.docs) {
 			if (child.slug) {
-				revalidateTag(`events_${child.slug}`, {});
+				revalidateEventDocumentTags(child.slug);
 			}
 		}
 	}
@@ -49,8 +75,8 @@ export const revalidateEventDelete: CollectionAfterDeleteHook<Event> = async ({
 	if (doc._status === 'published') {
 		payload.logger.info(`Revalidating deleted event: ${doc.slug}`);
 
-		revalidateTag(`events_${doc.slug}`, {});
-		revalidateTag('events', {});
+		revalidateEventDocumentTags(doc.slug);
+		revalidateEventListTags();
 
 		const children = await payload.find({
 			collection: 'events',
@@ -62,7 +88,7 @@ export const revalidateEventDelete: CollectionAfterDeleteHook<Event> = async ({
 
 		for (const child of children.docs) {
 			if (child.slug) {
-				revalidateTag(`events_${child.slug}`, {});
+				revalidateEventDocumentTags(child.slug);
 			}
 		}
 	}

--- a/src/modules/payload/payload.config.ts
+++ b/src/modules/payload/payload.config.ts
@@ -12,7 +12,6 @@ import { defaultLexical } from '../editor/lexical';
 import { seoPlugin } from '../seo/plugin';
 import { storagePlugin } from '../storage/plugin';
 import { collections } from './collections';
-import { migrations } from './db/migrations';
 import { globals } from './globals';
 
 const filename = fileURLToPath(import.meta.url);
@@ -74,11 +73,9 @@ export default buildConfig({
 			'./db/payload-generated-schema.ts'
 		),
 		migrationDir: path.resolve(dirname, './db/migrations'),
-		// @ts-expect-error - known type mismatch between @payloadcms/drizzle and @payloadcms/db-sqlite migration types
-		prodMigrations: migrations,
 		push: false,
 		client: {
-			url: process.env.TURSO_DATABASE_URL || process.env.DATABASE_URL || '',
+			url: process.env.DATABASE_URL || process.env.TURSO_DATABASE_URL || '',
 			authToken: process.env.TURSO_AUTH_TOKEN,
 		},
 	}),

--- a/src/modules/posts/revalidate.ts
+++ b/src/modules/posts/revalidate.ts
@@ -5,6 +5,28 @@ import type {
 	CollectionAfterChangeHook,
 	CollectionAfterDeleteHook,
 } from 'payload';
+import {
+	collectionBaseTag,
+	collectionTag,
+	documentBaseTag,
+	documentTag,
+	localesForInvalidation,
+} from '@/modules/utilities/cacheTags';
+
+function revalidatePostTags(slug?: string | null) {
+	if (slug) {
+		revalidateTag(documentBaseTag('posts', slug), {});
+	}
+
+	revalidateTag(collectionBaseTag('posts'), {});
+
+	for (const locale of localesForInvalidation) {
+		if (slug) {
+			revalidateTag(documentTag('posts', slug, locale), {});
+		}
+		revalidateTag(collectionTag('posts', locale), {});
+	}
+}
 
 export const revalidatePost: CollectionAfterChangeHook<Post> = ({
 	doc,
@@ -17,11 +39,7 @@ export const revalidatePost: CollectionAfterChangeHook<Post> = ({
 	if (doc._status === 'published') {
 		payload.logger.info(`Revalidating post: ${doc.slug}`);
 
-		// Revalidate specific post tag
-		revalidateTag(`posts_${doc.slug}`, {});
-
-		// Revalidate collection-level tag
-		revalidateTag('posts', {});
+		revalidatePostTags(doc.slug);
 	}
 
 	return doc;
@@ -38,9 +56,7 @@ export const revalidateDelete: CollectionAfterDeleteHook<Post> = ({
 	if (doc._status === 'published') {
 		payload.logger.info(`Revalidating deleted post: ${doc.slug}`);
 
-		// Clean up cache for deleted post
-		revalidateTag(`posts_${doc.slug}`, {});
-		revalidateTag('posts', {});
+		revalidatePostTags(doc.slug);
 	}
 
 	return doc;

--- a/src/modules/resources/partners.ts
+++ b/src/modules/resources/partners.ts
@@ -1,7 +1,6 @@
 import type { About } from '@payload-types';
 import type { OptionObject, PayloadRequest } from 'payload';
 import type { Locales } from '@/i18n/routing';
-import { getGlobal } from '@/modules/utilities/getGlobals';
 
 type AboutPartner = NonNullable<About['partners']>[number];
 
@@ -18,6 +17,7 @@ export function getValidPartners(
 export async function getPartnerOptions(
 	locale?: Locales
 ): Promise<OptionObject[]> {
+	const { getGlobal } = await import('@/modules/utilities/getGlobals');
 	const about = (await getGlobal('about', 0, locale)) as About;
 
 	return getValidPartners(about).map((partner) => ({

--- a/src/modules/resources/queries.ts
+++ b/src/modules/resources/queries.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import type { About, Image, Resource, Tag } from '@payload-types';
 import type { DefaultTypedEditorState } from '@payloadcms/richtext-lexical';
 import type { PaginatedDocs, Where } from 'payload';

--- a/src/modules/resources/revalidate.ts
+++ b/src/modules/resources/revalidate.ts
@@ -3,6 +3,23 @@ import type {
 	CollectionAfterChangeHook,
 	CollectionAfterDeleteHook,
 } from 'payload';
+import {
+	collectionBaseTag,
+	collectionTag,
+	documentBaseTag,
+	documentTag,
+	localesForInvalidation,
+} from '@/modules/utilities/cacheTags';
+
+function revalidateResourceTags(slug: string) {
+	revalidateTag(documentBaseTag('resources', slug), {});
+	revalidateTag(collectionBaseTag('resources'), {});
+
+	for (const locale of localesForInvalidation) {
+		revalidateTag(documentTag('resources', slug, locale), {});
+		revalidateTag(collectionTag('resources', locale), {});
+	}
+}
 
 export const revalidateResource: CollectionAfterChangeHook = ({
 	doc,
@@ -14,8 +31,7 @@ export const revalidateResource: CollectionAfterChangeHook = ({
 
 	if (doc._status === 'published') {
 		payload.logger.info(`Revalidating resource: ${doc.slug}`);
-		revalidateTag(`resources_${doc.slug}`, {});
-		revalidateTag('resources', {});
+		revalidateResourceTags(doc.slug);
 	}
 
 	return doc;
@@ -31,8 +47,7 @@ export const revalidateResourceDelete: CollectionAfterDeleteHook = ({
 
 	if (doc._status === 'published') {
 		payload.logger.info(`Revalidating deleted resource: ${doc.slug}`);
-		revalidateTag(`resources_${doc.slug}`, {});
-		revalidateTag('resources', {});
+		revalidateResourceTags(doc.slug);
 	}
 
 	return doc;

--- a/src/modules/utilities/cacheTags.test.ts
+++ b/src/modules/utilities/cacheTags.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+	collectionBaseTag,
+	collectionTag,
+	documentBaseTag,
+	documentTag,
+	globalBaseTag,
+	globalTag,
+} from './cacheTags';
+
+describe('cache tag helpers', () => {
+	it('creates locale-aware document tags and stable base document tags', () => {
+		expect(documentTag('posts', 'alpha', 'it')).toBe('posts:it:doc:alpha');
+		expect(documentTag('posts', 'alpha', 'en')).toBe('posts:en:doc:alpha');
+		expect(documentTag('posts', 'alpha', 'it')).not.toBe(
+			documentTag('posts', 'alpha', 'en')
+		);
+		expect(documentBaseTag('posts', 'alpha')).toBe('posts:doc:alpha');
+	});
+
+	it('creates locale-aware collection tags and stable base collection tags', () => {
+		expect(collectionTag('posts', 'it')).toBe('posts:it:list');
+		expect(collectionTag('posts', 'en')).toBe('posts:en:list');
+		expect(collectionTag('posts', 'it')).not.toBe(collectionTag('posts', 'en'));
+		expect(collectionBaseTag('posts')).toBe('posts:list');
+	});
+
+	it('creates locale-aware global tags and stable base global tags', () => {
+		expect(globalTag('home', 'it')).toBe('global:it:home');
+		expect(globalTag('home', 'en')).toBe('global:en:home');
+		expect(globalTag('home', 'it')).not.toBe(globalTag('home', 'en'));
+		expect(globalBaseTag('home')).toBe('global:home');
+	});
+});

--- a/src/modules/utilities/cacheTags.ts
+++ b/src/modules/utilities/cacheTags.ts
@@ -1,0 +1,25 @@
+export const localesForInvalidation = ['it', 'en'] as const;
+
+export function documentTag(collection: string, slug: string, locale?: string) {
+	return `${collection}:${locale ?? 'default'}:doc:${slug}`;
+}
+
+export function documentBaseTag(collection: string, slug: string) {
+	return `${collection}:doc:${slug}`;
+}
+
+export function collectionTag(collection: string, locale?: string) {
+	return `${collection}:${locale ?? 'default'}:list`;
+}
+
+export function collectionBaseTag(collection: string) {
+	return `${collection}:list`;
+}
+
+export function globalTag(slug: string, locale?: string) {
+	return `global:${locale ?? 'default'}:${slug}`;
+}
+
+export function globalBaseTag(slug: string) {
+	return `global:${slug}`;
+}

--- a/src/modules/utilities/getDocument.ts
+++ b/src/modules/utilities/getDocument.ts
@@ -1,29 +1,47 @@
+import 'server-only';
+
 import configPromise from '@payload-config';
 import type { Config } from '@payload-types';
 import { cacheLife, cacheTag } from 'next/cache';
 import type { SelectFromCollectionSlug } from 'node_modules/payload/dist/collections/config/types';
 import { getPayload, type Where } from 'payload';
 import type { Locales } from '@/i18n/routing';
+import {
+	collectionBaseTag,
+	collectionTag,
+	documentBaseTag,
+	documentTag,
+} from './cacheTags';
 
 type Collection = keyof Config['collections'];
 
-export async function getDocument({
-	collection,
-	slug,
-	depth = 0,
-	draft = false,
-	locale,
-}: {
+interface GetDocumentArgs {
 	collection: Collection;
 	slug: string;
 	depth?: number;
 	draft?: boolean;
 	locale?: Locales;
-}): Promise<Config['collections'][Collection] | undefined> {
-	'use cache';
-	cacheLife('max');
-	cacheTag(`${collection}_${slug}`);
+}
 
+interface GetDocumentsArgs {
+	collection: Collection;
+	depth?: number;
+	limit?: number;
+	page?: number;
+	sort?: string;
+	draft?: boolean;
+	where?: Where;
+	select?: SelectFromCollectionSlug<Collection>;
+	locale?: Locales;
+}
+
+async function findDocumentUncached({
+	collection,
+	slug,
+	depth = 0,
+	draft = false,
+	locale,
+}: GetDocumentArgs): Promise<Config['collections'][Collection] | undefined> {
 	const payload = await getPayload({ config: configPromise });
 	const result = await payload.find({
 		collection,
@@ -37,7 +55,43 @@ export async function getDocument({
 	return result.docs[0] as Config['collections'][Collection] | undefined;
 }
 
-export async function getDocuments({
+async function findPublishedDocumentCached({
+	collection,
+	slug,
+	depth = 0,
+	locale,
+}: GetDocumentArgs): Promise<Config['collections'][Collection] | undefined> {
+	'use cache';
+	cacheLife('max');
+	cacheTag(
+		documentBaseTag(collection, slug),
+		documentTag(collection, slug, locale)
+	);
+
+	const payload = await getPayload({ config: configPromise });
+	const result = await payload.find({
+		collection,
+		where: { slug: { equals: slug } },
+		depth,
+		draft: false,
+		overrideAccess: false,
+		locale,
+	});
+
+	return result.docs[0] as Config['collections'][Collection] | undefined;
+}
+
+export async function getDocument(
+	args: GetDocumentArgs
+): Promise<Config['collections'][Collection] | undefined> {
+	if (args.draft) {
+		return findDocumentUncached(args);
+	}
+
+	return findPublishedDocumentCached(args);
+}
+
+async function findDocumentsUncached({
 	collection,
 	depth = 0,
 	limit = 12,
@@ -47,21 +101,7 @@ export async function getDocuments({
 	where,
 	select,
 	locale,
-}: {
-	collection: Collection;
-	depth?: number;
-	limit?: number;
-	page?: number;
-	sort?: string;
-	draft?: boolean;
-	where?: Where;
-	select?: SelectFromCollectionSlug<Collection>;
-	locale?: Locales;
-}) {
-	'use cache';
-	cacheLife('max');
-	cacheTag(collection);
-
+}: GetDocumentsArgs) {
 	const payload = await getPayload({ config: configPromise });
 	return payload.find({
 		collection,
@@ -75,4 +115,41 @@ export async function getDocuments({
 		select,
 		locale,
 	});
+}
+
+async function findPublishedDocumentsCached({
+	collection,
+	depth = 0,
+	limit = 12,
+	page = 1,
+	sort = 'publishedAt',
+	where,
+	select,
+	locale,
+}: GetDocumentsArgs) {
+	'use cache';
+	cacheLife('max');
+	cacheTag(collectionBaseTag(collection), collectionTag(collection, locale));
+
+	const payload = await getPayload({ config: configPromise });
+	return payload.find({
+		collection,
+		depth,
+		limit,
+		page,
+		sort,
+		where,
+		draft: false,
+		overrideAccess: false,
+		select,
+		locale,
+	});
+}
+
+export async function getDocuments(args: GetDocumentsArgs) {
+	if (args.draft) {
+		return findDocumentsUncached(args);
+	}
+
+	return findPublishedDocumentsCached(args);
 }

--- a/src/modules/utilities/getGlobals.ts
+++ b/src/modules/utilities/getGlobals.ts
@@ -1,8 +1,11 @@
+import 'server-only';
+
 import configPromise from '@payload-config';
 import type { Config } from '@payload-types';
 import { cacheLife, cacheTag } from 'next/cache';
 import { getPayload } from 'payload';
 import type { Locales } from '@/i18n/routing';
+import { globalBaseTag, globalTag } from './cacheTags';
 
 type Global = keyof Config['globals'];
 
@@ -13,7 +16,7 @@ export async function getGlobal(
 ): Promise<Config['globals'][Global]> {
 	'use cache';
 	cacheLife('max');
-	cacheTag(`global_${slug}`);
+	cacheTag(globalBaseTag(slug), globalTag(slug, locale));
 
 	const payload = await getPayload({ config: configPromise });
 	return (await payload.findGlobal({

--- a/src/modules/utilities/revalidateGlobal.ts
+++ b/src/modules/utilities/revalidateGlobal.ts
@@ -1,6 +1,7 @@
 import { revalidateTag } from 'next/cache';
 
 import type { GlobalAfterChangeHook } from 'payload';
+import { globalBaseTag, globalTag, localesForInvalidation } from './cacheTags';
 
 export const revalidateGlobal: GlobalAfterChangeHook = ({
 	global,
@@ -12,8 +13,11 @@ export const revalidateGlobal: GlobalAfterChangeHook = ({
 
 	payload.logger.info(`Revalidating ${global.slug} global`);
 
-	// Single tag revalidation - simpler and more efficient
-	revalidateTag(`global_${global.slug}`, {});
+	revalidateTag(globalBaseTag(global.slug), {});
+
+	for (const locale of localesForInvalidation) {
+		revalidateTag(globalTag(global.slug, locale), {});
+	}
 
 	return global;
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		include: ['src/**/*.test.ts'],
+	},
+});


### PR DESCRIPTION
## Summary
- Tightened preview-route validation to reject malformed, external, and traversal-style paths before enabling preview mode.
- Improved error handling in the frontend error boundary by logging route digests and showing a stable fallback message.
- Added cache-tag helpers and broader revalidation coverage for authors, posts, events, resources, and globals.
- Strengthened local data safety for `pull-prod.sh` and `sync-media.sh` so production sources only flow into local SQLite and local MinIO.
- Added Vitest-based tests for preview path validation and cache-tag behavior, plus `test` and `verify` package scripts.
- Updated docs and environment examples to reflect the new local/production separation.

## Testing
- Ran `vitest` suite additions for preview path validation and cache-tag helpers.
- Not run: `pnpm test`
- Not run: `pnpm typecheck`
- Not run: `pnpm exec biome check .`
- Not run: `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened preview validation and locked down local prod-to-dev sync to prevent unsafe paths and writes. Added locale-aware cache tags with broader revalidation and `vitest` tests to improve stability across preview, caching, and local workflows.

- New Features
  - Validate preview paths server-side and return 400 for malformed/external/traversal paths; added tests for `isValidPreviewPath`.
  - Locale-aware cache-tag helpers with expanded revalidation for authors, posts, events (including children), resources, and globals; `getDocument(s)` and `getGlobal` now use base + locale tags.
  - Safer local sync: `scripts/pull-prod.sh` reads from `TURSO_DATABASE_URL` and writes only to local SQLite; `scripts/sync-media.sh` reads from `R2_*` and writes only to local MinIO, enforcing `S3_ENDPOINT=http://localhost:9000`.
  - Error boundary logs route digests and shows a consistent fallback message.
  - Added `test`, `verify`, and `build:next` scripts and introduced `vitest`; marked server modules with `server-only`.

- Migration
  - Update `.env` with `TURSO_*` and `R2_*` for scripts; keep `DATABASE_URL=file:payload.sqlite` locally. Deploys may use `TURSO_DATABASE_URL` only when `DATABASE_URL` is unset.
  - Refresh local data with `scripts/pull-prod.sh` (calls `scripts/sync-media.sh`) then build; local uploads must target `S3_ENDPOINT=http://localhost:9000`.
  - Use `pnpm test` or `pnpm verify` to run the new checks.

<sup>Written for commit e427cd9017c100ade10deef29e2a1425887f7a18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

