### PR TITLE
Enable 20MB direct image uploads to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ SQLite and local MinIO.
 	`scripts/sync-media.sh`; Payload runtime must use `S3_*` instead.
 - `S3_*` config is the runtime upload target. Local uploads must use
 	`S3_ENDPOINT=http://localhost:9000`.
+- Payload uploads use direct browser-to-S3/R2 writes in deployed environments,
+	so the runtime bucket CORS policy must allow `PUT` from the site origin.
 
 Fresh local dataset workflow:
 

--- a/src/modules/payload/payload.config.ts
+++ b/src/modules/payload/payload.config.ts
@@ -18,6 +18,7 @@ import { globals } from './globals';
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
 const isProduction = process.env.NODE_ENV === 'production';
+const MAX_UPLOAD_FILE_SIZE_BYTES = 20 * 1024 * 1024;
 
 function requireProductionEnv(name: string): string | undefined {
 	const value = process.env[name]?.trim();
@@ -50,6 +51,13 @@ export default buildConfig({
 	defaultDepth: 1,
 	maxDepth: 4,
 	defaultMaxTextLength: 20_000,
+	upload: {
+		abortOnLimit: true,
+		limits: {
+			fileSize: MAX_UPLOAD_FILE_SIZE_BYTES,
+		},
+		responseOnLimit: 'File size limit exceeded. Maximum upload size is 20MB.',
+	},
 	graphQL: {
 		disable: true,
 	},

--- a/src/modules/storage/plugin.ts
+++ b/src/modules/storage/plugin.ts
@@ -26,6 +26,7 @@ export const storagePlugin = s3Storage({
 		},
 	},
 	bucket: getS3Env('S3_BUCKET'),
+	clientUploads: true,
 	disableLocalStorage: true,
 	enabled: true,
 	config: {


### PR DESCRIPTION
## Summary
- Enabled direct browser-to-S3 uploads in the storage plugin so deployed environments can upload images without routing through the app server.
- Raised the Payload upload limit to 20MB and added a clear limit error message.
- Documented the required bucket CORS behavior for `PUT` requests from the site origin.

## Testing
- Not run (change is configuration-only).
- Reviewed the config changes for Payload upload limits and S3 client uploads.
- Confirmed the README note matches the new direct upload flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled direct browser-to-S3 uploads and raised the max upload size to 20MB. Faster production uploads and a clear error when the limit is exceeded.

- **Migration**
  - Update the bucket CORS policy to allow PUT requests from the site origin.

<sup>Written for commit ce35664feece2013496b70a8167ee6236916d860. Summary will update on new commits. <a href="https://cubic.dev/pr/eui-goccia/eui-goccia-cms/pull/34?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

