### PR TITLE
Render internal editor links with Next.js Link

### DIFF
--- a/src/modules/editor/component.tsx
+++ b/src/modules/editor/component.tsx
@@ -32,6 +32,9 @@ const isSluggableDoc = (
 ): value is { slug: string; [key: string]: unknown } =>
 	isPopulatedDoc(value) && 'slug' in value && typeof value.slug === 'string';
 
+const isInternalHref = (href: string) =>
+	href.startsWith('/') && !href.startsWith('//');
+
 type NodeTypes =
 	| DefaultNodeTypes
 	| SerializedBlockNode<QuoteBlock | ImageBlock | TextBlock | GridBlock>;
@@ -81,10 +84,18 @@ const CustomLinkConverter: JSXConverter<SerializedLinkNode> = async ({
 		? { target: '_blank', rel: 'noopener noreferrer' }
 		: {};
 
+	if (isInternalHref(href)) {
+		return (
+			<Link href={href} locale={locale} {...newTabProps}>
+				{renderedChildren}
+			</Link>
+		);
+	}
+
 	return (
-		<Link href={href ?? '#'} locale={locale} {...newTabProps}>
+		<a href={href} {...newTabProps}>
 			{renderedChildren}
-		</Link>
+		</a>
 	);
 };
 


### PR DESCRIPTION
## Summary
- Render internal editor links through Next.js `Link` when the href is a same-origin path.
- Keep external links as plain anchor tags, preserving new-tab behavior and security attributes.
- Add a small helper to distinguish internal paths from protocol-relative URLs.

## Testing
- Not run (not requested).
- Reviewed the updated link rendering logic in `src/modules/editor/component.tsx` for internal vs. external href handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render internal editor links with Next.js `Link` to enable client-side, locale-aware navigation and avoid full page reloads. External and protocol-relative (`//`) URLs are rendered as `<a>` with new-tab and security attributes.

<sup>Written for commit c0148d8219aa8ab36d6d265304988049f37b2c74. Summary will update on new commits. <a href="https://cubic.dev/pr/eui-goccia/eui-goccia-cms/pull/35?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

